### PR TITLE
Fix binary search

### DIFF
--- a/algorithms/Searching/binary_search.m
+++ b/algorithms/Searching/binary_search.m
@@ -14,7 +14,7 @@ counter = 0;                                      % number of iteration in searc
 L_SearchRange = 1;                                %initial search range
 R_SearchRange = array_length;
 
-while counter <= floor(log(array_length))+1       %maximum iteration needed to find the target
+while counter <= floor(log2(array_length))+1       %maximum iteration needed to find the target
 mid = (L_SearchRange + R_SearchRange)/2;
 
 if t == A(floor(mid))
@@ -31,7 +31,7 @@ else if t > A(floor(mid))
  counter = counter+1; 
 end
 end
-if counter > floor(log(array_length))+1
+if counter > floor(log2(array_length))+1
     disp('target is not found in aray')
 end
 end


### PR DESCRIPTION
Current binary search implementation has bug. For example,
```
>> binary_search(1:100, 30)
target is not found in aray
```
```
>> binary_search(1:100, 70)
target is not found in aray
```

The bug is in `maximum iteration needed to find the target`. There should be binary logarithm `log2` instead of natural `log`.  In case of natural logarithm `log` algorithm lacks iterations in some cases (e.g. in above). But in some cases it works properly. For example,
```
>> binary_search(1:100, 50)

ans =

    50
```