### PR TITLE
Fix random search

### DIFF
--- a/algorithms/Searching/random_search.m
+++ b/algorithms/Searching/random_search.m
@@ -16,7 +16,7 @@ numIter=100;
 ObjFun=@(x) sum(x.^2);
 for i=1:numIter
     candidate=10*rand(dim,popsize)-5;
-    best,=min(feval(ObjFun,candidate));
+    best=min(feval(ObjFun,candidate));
     if best <= ftarget
         break;
     end


### PR DESCRIPTION
Current random search implementation doesn't run.
In Octave:
```
>> random_search

error: parse error near line 19 of file D:\MATLAB-Octave\algorithms\Searching\random_search.m

  syntax error

>>>     best,=min(feval(ObjFun,candidate));
```
In MATLAB:
```
>> random_search
Error: File: random_search.m Line: 19 Column: 10
Incorrect use of '=' operator. To assign a value to a variable, use '='. To compare values
for equality, use '=='.
```
It has syntax error - redundant comma `,` in line `19`:
```
best,=min(feval(ObjFun,candidate));
```