### PR TITLE
Improve counting sort

### DIFF
--- a/algorithms/sorting/counting_sort.m
+++ b/algorithms/sorting/counting_sort.m
@@ -3,11 +3,10 @@ function ans = counting_sort(arr, k)
   % INPUT: array of integers between 1 and k
   % OUTPUT: sorted array
 
-  ans = []; % result array (sorted array)
+  ans = zeros(size(arr)); % result array (sorted array)
 
 
-  C = zeros(k); % array for counting
-  C = C(1,:);
+  C = zeros(1,k); % array for counting
 
   % counts the occurs of element i
   for i = 1 : length(arr)
@@ -15,10 +14,8 @@ function ans = counting_sort(arr, k)
   endfor
 
   % adress calculation
-  for j = 1 : k
-    if j > 1
-      C(j) += C(j-1);
-    endif
+  for j = 2 : k
+    C(j) += C(j-1);
   endfor
 
   for m = length(arr) : -1 : 1


### PR DESCRIPTION
1. Preallocate  `ans`
2. Decrease memory consumption for `C` creation
```
>> k = 100000;
>> counting_sort(1:k, k)
error: out of memory or dimension too large for Octave's index type
error: called from
    counting_sort at line 9 column 5
```
3. Remove unnecessary `if` statement