### PR TITLE
Fix multiple

### DIFF
--- a/algorithms/Divisibility_of_integers/multiple.m
+++ b/algorithms/Divisibility_of_integers/multiple.m
@@ -6,7 +6,7 @@ function ans = multiple(x, m)
   % OUTPUT: Is a boolean value 0 or 1.
   % THROWS: Throws a assertion error if the inputs invalid.
 
-  assert((isnumeric(x) && isnumeric(m)), "The inputs must be integers")
+  assert((x == round(x) && m == round(m)), "The inputs must be integers")
 
   if m == 0 
     ans = (x == 0);


### PR DESCRIPTION
Function `isnumeric` doesn't determine whether input is integer, it determines whether input is numeric. So, it returns `true` for non-integer floating-point numbers. So, `assert` doesn't work when inputs are non-integer floating-point numbers.

Before:
```
>> multiple(1.5, 2.5)
ans = 0
```

After:
```
>> multiple(1.5, 2.5)
error: The inputs must be integers
error: called from
    assert at line 101 column 11
    multiple at line 9 column 3
```